### PR TITLE
PokerTH V.1.1.2 10-max DefaultTheme TM

### DIFF
--- a/##_OpenHoldem_Release_Directory_##/scraper/Simulators/PokerTH/PokerTH-1.1.2_Mudr0x_W10_DefaultTheme.tm
+++ b/##_OpenHoldem_Release_Directory_##/scraper/Simulators/PokerTH/PokerTH-1.1.2_Mudr0x_W10_DefaultTheme.tm
@@ -1,0 +1,2706 @@
+.osdb2
+
+// OpenScrape 13.1.3
+
+// 32 bits per pixel
+
+//
+// sizes
+//
+
+z$clientsizemax    2000  1600
+z$clientsizemin    600  400
+z$targetsize       1024  600
+
+//
+// strings
+//
+
+s$H0type                    fuzzy
+s$betsizeconfirmationmethod Click Bet
+s$betsizedeletionmethod     Delete
+s$betsizeinterpretationmethod 1
+s$betsizeselectionmethod    Dbl Click
+s$c0limits                  ^L
+s$nchairs                   10
+s$network                   pokerth
+s$potmethod                 1
+s$sitename                  pokerth
+s$t0type                    0.0
+s$t2type                    0.0
+s$t3type                    0.0
+s$titletext                 PokerTH
+s$titletext0                Holdem Engine
+s$ttlimits                  ^*H ^y
+
+//
+// regions
+//
+
+r$c0cardface0        394 181 403 220 fff0f0f0    0 H0
+r$c0cardface0nocard  393 245 393 248 fff0f0f0   -1 C
+r$c0cardface1        449 181 458 220 fff0f0f0    0 H0
+r$c0cardface1nocard  449 245 449 248 fff0f0f0   -1 C
+r$c0cardface2        504 181 513 220 fff0f0f0    0 H0
+r$c0cardface2nocard  504 245 504 248 fff0f0f0   -1 C
+r$c0cardface3        559 181 568 220 fff0f0f0    0 H0
+r$c0cardface3nocard  559 245 559 248 fff0f0f0   -1 C
+r$c0cardface4        614 181 623 220 fff0f0f0    0 H0
+r$c0cardface4nocard  614 245 614 248 fff0f0f0   -1 C
+r$c0handnumber       741 240 796 250 ff009966   40 T0
+r$c0pot0             287 219 357 229 ff009966   40 T2
+r$c0pot1             287 255 357 265 ff009966   40 T2
+r$i0button           455 556 575 585        0    0 N
+r$i0label            487 565 532 577 fff0f0f0  150 T2
+r$i0state            497 571 497 572 fff0f0f0   40 C
+r$i1button           455 512 575 541        0    0 N
+r$i1label            492 512 537 526 fff0f0f0  150 T2
+r$i1state            499 518 500 519 fff0f0f0   40 C
+r$i2button           455 467 575 497        0    0 N
+r$i2label            488 469 533 482 fff0f0f0  150 T2
+r$i2state            511 477 511 477 fff0f0f0   40 C
+r$i3button           521 419 576 432 ff228cb4    0 N
+r$i3edit             431 420 431 430        0    0 N
+r$i3label            529 421 546 430        0    0 H0
+r$i3state            541 425 542 426 fff0f0e4   40 C
+r$i4button           455 512 575 541        0    0 N
+r$i4label            488 522 536 532 fff0f0f0    0 T2
+r$i4state            499 527 500 528 fff0f0f0   40 C
+r$p0active           637  77 650  80 ff005a16  -10 C
+r$p0balance          687  48 756  57 ff00ffff   90 T0
+r$p0bet              705 142 783 151 ff00ffff  100 T0
+r$p0cardback         713  60 722  61 ff005a16   -5 C
+r$p0cardface0        711  63 720 102 fff0f0f0    0 H0
+r$p0cardface0nocard  711  79 711  82 fff3f3f5   -2 C
+r$p0cardface1        735  63 744 102 fff0f0f0    0 H0
+r$p0cardface1nocard  735  79 735  82 fff4f4f5   -2 C
+r$p0dealer           657 110 663 111 ffb4b4b4    5 C
+r$p0name             687  33 776  43 fff0f0f0  140 T0
+r$p0seated           637  77 650  80 ff005a16  -10 C
+r$p1active           846 112 859 115 ff005a16  -10 C
+r$p1balance          896  83 965  92 ff00ffff   90 T0
+r$p1bet              912 177 990 186 ff00ffff  100 T0
+r$p1cardback         923  95 932  96 ff005614   -5 C
+r$p1cardface0        920  98 929 137 fff0f0f0    0 H0
+r$p1cardface0nocard  920 114 920 117 fff3f3f5   -2 C
+r$p1cardface1        944  98 953 137 fff0f0f0    0 H0
+r$p1cardface1nocard  944 114 944 117 fff4f4f5   -2 C
+r$p1dealer           866 145 872 146 ffb4b4b4    5 C
+r$p1name             896  68 990  78 fff0f0f0  140 T0
+r$p1seated           846 112 859 115 ff005a16  -10 C
+r$p2active           845 357 858 360 ff004f12  -10 C
+r$p2balance          896 337 965 346 ff00ffff   90 T0
+r$p2bet              912 244 990 253 ff00ffff  100 T0
+r$p2cardback         923 258 932 259 ff005314   -5 C
+r$p2cardface0        920 261 929 300 fff0f0f0    0 H0
+r$p2cardface0nocard  920 279 920 282 fff3f3f5   -2 C
+r$p2cardface1        944 261 953 300 fff0f0f0    0 H0
+r$p2cardface1nocard  944 279 944 282 fff4f4f5   -2 C
+r$p2dealer           866 249 872 250 ffb4b4b4    5 C
+r$p2name             896 350 990 360 fff0f0f0  140 T0
+r$p2seated           845 357 858 360 ff004f12  -10 C
+r$p3active           637 392 650 395 ff005614  -10 C
+r$p3balance          687 372 756 381 ff00ffff   90 T0
+r$p3bet              706 279 784 288 ff00ffff  100 T0
+r$p3cardback         714 293 723 294 ff005a14   -5 C
+r$p3cardface0        711 296 720 335 fff0f0f0    0 H0
+r$p3cardface0nocard  711 314 711 317 fff3f3f5   -2 C
+r$p3cardface1        735 296 744 335 fff0f0f0    0 H0
+r$p3cardface1nocard  735 314 735 317 fff4f4f5   -2 C
+r$p3dealer           656 284 662 285 ffb4b4b4    5 C
+r$p3name             687 385 781 395 fff0f0f0  140 T0
+r$p3seated           637 392 650 395 ff005614  -10 C
+r$p4active           430 391 443 394 ff005a14  -10 C
+r$p4balance          480 372 549 381 ff00ffff   90 T0
+r$p4bet              498 279 576 288 ff00ffff  100 T0
+r$p4cardback         506 370 515 371 fff0f0f0    5 C
+r$p4cardface0        504 296 513 335 fff0f0f0    0 H0
+r$p4cardface0nocard  502 318 502 318 ff004d13   -2 C
+r$p4cardface1        528 296 537 335 fff0f0f0    0 H0
+r$p4cardface1nocard  526 317 526 317 ffcccccc   -2 C
+r$p4dealer           450 285 456 286 ffbbbbbb    5 C
+r$p4name             480 385 577 395 fff0f0f0  140 T0
+r$p4seated           430 391 443 394 ff005a14  -10 C
+r$p5active           223 391 236 394 ff005314  -10 C
+r$p5balance          273 373 342 382 ff00ffff   90 T0
+r$p5bet              293 279 371 288 ff00ffff  100 T0
+r$p5cardback         300 293 309 294 ff005c16   -5 C
+r$p5cardface0        297 296 306 335 fff0f0f0    0 H0
+r$p5cardface0nocard  297 314 297 317 fff3f3f5   -2 C
+r$p5cardface1        321 296 330 335 fff0f0f0    0 H0
+r$p5cardface1nocard  321 314 321 317 fff4f4f5   -2 C
+r$p5dealer           243 285 249 286 ffbbbbbb    5 C
+r$p5name             273 385 367 395 fff0f0f0  140 T0
+r$p5seated           223 391 236 394 ff005314  -10 C
+r$p6active            15 357  28 360 ff005414  -10 C
+r$p6balance           65 338 134 347 ff00ffff   90 T0
+r$p6bet               85 244 163 253 ff00ffff  100 T0
+r$p6cardback          93 258 102 259 ff004d12   -5 C
+r$p6cardface0         90 261  99 300 fff0f0f0    0 H0
+r$p6cardface0nocard   90 279  90 282 fff3f3f5   -2 C
+r$p6cardface1        114 261 123 300 fff0f0f0    0 H0
+r$p6cardface1nocard  114 279 114 282 fff4f4f5   -2 C
+r$p6dealer            35 249  41 250 ffb4b4b4    5 C
+r$p6name              65 350 159 360 fff0f0f0  140 T0
+r$p6seated            15 357  28 360 ff005414  -10 C
+r$p7active            16 112  29 115 ff005414  -10 C
+r$p7balance           66  83 135  92 ff00ffff   90 T0
+r$p7bet               85 177 163 186 ff00ffff  100 T0
+r$p7cardback          93  96 102  97 ff005314   -5 C
+r$p7cardface0         90  98  99 137 fff0f0f0    0 H0
+r$p7cardface0nocard   90 115  90 118 fff6f6f7   -4 C
+r$p7cardface1        114  98 123 137 fff0f0f0    0 H0
+r$p7cardface1nocard  114 115 114 118 fff4f4f5   -4 C
+r$p7dealer            35 145  41 146 ffb4b4b4    5 C
+r$p7name              66  68 160  78 fff0f0f0  140 T0
+r$p7seated            16 112  29 115 ff005414  -10 C
+r$p8active           223  77 236  80 ff005314  -10 C
+r$p8balance          273  48 342  57 ff00ffff   90 T0
+r$p8bet              292 142 370 151 ff00ffff  100 T0
+r$p8cardback         300  60 309  61 ff005a16   -5 C
+r$p8cardface0        297  63 306 102 fff0f0f0    0 H0
+r$p8cardface0nocard  297  79 297  82 fff3f3f5   -2 C
+r$p8cardface1        321  63 330 102 fff0f0f0    0 H0
+r$p8cardface1nocard  321  79 321  82 fff4f4f5   -2 C
+r$p8dealer           244 110 250 111 ffb4b4b4    5 C
+r$p8name             273  33 367  43 fff0f0f0  140 T0
+r$p8seated           223  77 236  80 ff005314  -10 C
+r$p9active           430  77 443  80 ff005c16  -10 C
+r$p9balance          480  48 549  57 ff00ffff   90 T0
+r$p9bet              499 142 577 151 ff00ffff  100 T0
+r$p9cardback         507  60 516  61 ff005a14   -5 C
+r$p9cardface0        504  63 513 102 fff0f0f0    0 H0
+r$p9cardface0nocard  504  79 504  82 fff3f3f5   -2 C
+r$p9cardface1        528  63 537 102 fff0f0f0    0 H0
+r$p9cardface1nocard  528  79 528  82 fff4f4f5   -2 C
+r$p9dealer           449 110 455 111 ffb4b4b4    5 C
+r$p9name             480  33 574  43 fff0f0f0  140 T0
+r$p9seated           430  77 443  80 ff005c16  -10 C
+
+//
+// fonts
+//
+
+t0$7 100 101 107 11e 178 1e0 180
+t0$7 100 101 107 11f 17c 1f0 1c0
+t0$1 101 101 1ff 1ff 1 1
+t0$2 1 103 107 10f 19d 1f9 f1
+t0$$ 11 79 59 7f 4d e
+t0$4 14 24 44 ff ff 4
+t0$j 1 6ff 6fe
+t0$4 18 28 48 88 108 1ff 1ff 8
+t0$4 18 68 c8 188 1ff 1ff 8 8
+t0$s 19 3d 2d 2f 26
+t0$i 1bf 1bf
+t0$e 1e 2b 29 29 19
+t0$d 1e 3f 21 21 1ff 1ff
+t0$c 1e 3f 21 21 21
+t0$o 1e 3f 21 21 3f 1e
+t0$e 1e 3f 29 29 39 19
+t0$e 1e 3f 2b 29 39 19
+t0$é 1e 3f a9 1a9 139 19
+t0$, 1 e c
+t0$5 1 f1 91 91 9f e
+t0$5 1f2 1e1 121 121 133 13f 1e
+t0$A 1 f 7e e4 e4 7e f 1
+t0$l 1ff 1ff
+t0$h 1ff 1ff 20 20 3f 1f
+t0$b 1ff 1ff 21 21 3f 1e
+t0$k 1ff 1ff c 1e 33 21
+t0$f 20 ff 1ff 120 120
+t0$t 20 ff ff 21 21
+t0$x 21 33 1e c 1e 33 21
+t0$5 2 1e1 1e1 121 121 13f 11e
+t0$$ 22 f2 b2 1ff 9a 9c
+t0$$ 22 f2 b2 bf 9a 9c
+t0$$ 22 f2 b2 ff 9a 1c
+t0$$ 22 f2 b2 ff 9a 9c
+t0$z 23 27 2d 39 31
+t0$a 2f 29 29 29 1f
+t0$v 30 3c f 3 f 3c 30
+t0$$ 31 39 59 ff 4d 4e 46
+t0$. 3 3
+t0$w 38 3f 7 1c 30 1c 7 3f 38
+t0$0 3c 7e 81 81 7e 3c
+t0$6 3c 7e 91 91 9e e
+t0$6 3c 7e 91 91 9f e
+t0$C 3c 7e c3 81 81 81 c3
+t0$O 3c 7e c3 81 81 c3 7e 3c
+t0$G 3c 7e c3 81 89 8f cf
+t0$u 3e 3f 1 1 3f 3f
+t0$6 3e 7b 91 91 9f e
+t0$6 3e 7f 91 91 9f e
+t0$6 3e ff d1 91 9f e
+t0$u 3f 3f 1 3 3f 3f
+t0$r 3f 3f 20 20
+t0$n 3f 3f 20 20 3f 1f
+t0$m 3f 3f 20 20 3f 3f 20 20 3f 1f
+t0$r 3f 3f 30 20
+t0$n 3f 3f 30 20 3f 3f
+t0$m 3f 3f 30 20 3f 3f 30 20 3f 3f
+t0$3 42 91 91 91 fe 6e
+t0$3 42 91 91 91 ff 6e
+t0$3 42 91 91 9b ff 6e
+t0$$ 62 72 b2 1ff 9a 9c 8c
+t0$$ 62 72 b2 1ff 9a 9e 8c
+t0$a 6 2f 29 29 3f 1f
+t0$$ 62 f2 b2 1ff 9a 9c 8c
+t0$$ 62 f2 b2 1ff 9a 9e 8c
+t0$8 6e ef 91 91 ef 6e
+t0$8 6e f1 91 91 ef 4
+t0$8 6e fb 91 91 ff 4e
+t0$8 6e fb 91 91 ff 66
+t0$8 6e fb 91 91 ff 6e
+t0$8 6e ff 91 91 ff 4e
+t0$8 6e ff 91 91 ff 66
+t0$8 6e ff 91 91 ff 6e
+t0$9 70 79 89 89 7e 3c
+t0$9 70 d9 89 89 7e 3c
+t0$9 70 f9 89 89 7e 3c
+t0$9 70 f9 89 8b ff 7c
+t0$9 70 f9 89 8b ff 7e
+t0$9 71 89 89 8b 7e 18
+t0$a 7 2f 29 2b 3f 1f
+t0$$ 72 f2 b2 1ff 9a 9e 9c
+t0$S 73 f9 99 99 df e
+t0$, 7 6
+t0$, 7 7
+t0$q 78 fc 84 84 ff ff
+t0$g 78 fd 85 85 ff fe
+t0$0 7c fe 101 101 101 fe 7c
+t0$0 7c fe 183 101 183 fe 7c
+t0$6 7c fe 1a1 121 121 13f 1e
+t0$6 7c fe 1a1 121 121 bf 1e
+t0$0 7e cb 81 81 7e 3c
+t0$6 7e d1 91 91 9e 4
+t0$0 7e d7 81 81 7e 3c
+t0$0 7e df 81 81 7e 3c
+t0$0 7e eb 81 81 7e 3c
+t0$0 7e ef 81 81 7e 3c
+t0$0 7e f3 81 81 7e 3c
+t0$0 7e fb 81 81 7e 3c
+t0$0 7e ff 81 81 7e 3c
+t0$0 7e ff 81 81 ff 7e
+t0$6 7e ff d1 91 9f e
+t0$T 80 80 80 ff ff 80 80 80
+t0$7 80 81 87 bc f0 c0
+t0$7 80 81 8f bc f0 c0
+t0$1 80 81 ff ff 1 1
+t0$7 80 83 8f bc e0 80
+t0$7 80 83 8f bc f0 c0
+t0$7 80 83 8f fe f8 e0
+t0$Y 80 e0 70 1f 1f 70 e0 80
+t0$y 80 e1 3b e 38 e0 80
+t0$y 80 e1 7f e 78 e0 80
+t0$V 80 f0 7e 7 7 7e f0 80
+t0$2 81 103 107 105 10d 199 f1 e1
+t0$2 81 103 107 10f 10d 199 1f1 e1
+t0$1 81 81 ff 1 1
+t0$1 81 81 ff ff 1 1
+t0$2 81 83 87 8d d9 71
+t0$2 81 83 87 8d f9 71
+t0$2 81 83 8d 99 71 61
+t0$2 81 83 8d 99 f1 61
+t0$X 81 e7 7e 18 18 7e e7 81
+t0$3 82 101 111 111 111 1ff ee
+t0$3 82 101 111 111 1b1 1ff ce
+t0$3 82 101 111 111 1bb 1ff ce
+t0$Z 83 87 8d 99 b1 e1 c1
+t0$2 83 87 8d 99 f1 61
+t0$2 83 87 8f 99 f9 61
+t0$3 91 91 91 fe
+t0$3 91 91 91 fe 6e
+t0$3 91 91 91 ff 2e
+t0$3 91 91 91 ff 4c
+t0$3 91 91 91 ff 66
+t0$3 91 91 91 ff 6e
+t0$3 91 91 91 ff e
+t0$y c0 f1 ff 1e 7c f0 80
+t0$W c0 f8 3f f 7c e0 7c f 3f f8 c0
+t0$4 c 14 24 84 ff ff 4
+t0$4 c 14 64 84 ff ff 4
+t0$e c 1e 29 29 39 19
+t0$4 c 24 44 c4 ff 4
+t0$4 c 34 44 c4 ff 4
+t0$4 c 34 64 c4 ff ff 4
+t0$y e1 79 1f 3c e0 80
+t0$$ e4 1e4 164 3ff 134 13c 138
+t0$8 ee 1ef 111 111 111 1ef ee
+t0$8 ee 1ff 111 111 111 1ff ee
+t0$Q f0 1f8 30c 204 206 30f 1f9 f0
+t0$9 f0 1fa 109 109 10b fe 7c
+t0$9 f0 f9 109 109 10b fe 7c
+t0$5 f1 f1 91 91 8e e
+t0$5 f1 f1 91 91 8f e
+t0$5 f1 f1 91 91 9e e
+t0$5 f1 f1 91 91 9f c
+t0$5 f1 f1 91 91 9f e
+t0$5 f1 f1 91 9b 9f e
+t0$U fe ff 1 1 1 ff fe
+t0$I ff ff
+t0$H ff ff 10 10 10 ff ff
+t0$L ff ff 1 1 1 1
+t0$K ff ff 18 3c 66 c3 81
+t0$D ff ff 81 81 c3 7e 3c
+t0$p ff ff 84 84 fc 78
+t0$P ff ff 88 88 88 70
+t0$P ff ff 88 88 88 70 70
+t0$P ff ff 88 88 88 f8 70
+t0$P ff ff 88 88 d8 f8 70
+t0$R ff ff 88 88 fe 77 1
+t0$F ff ff 90 90 90 90
+t0$E ff ff 91 91 91 91
+t0$B ff ff 91 91 91 ff 6e
+t0$N ff ff e0 18 7 ff ff
+t0$M ff ff e0 38 c 38 e0 ff ff
+t2$7 100 101 107 11e 178 1e0 180
+t2$7 100 101 107 11f 17c 1f0 1c0
+t2$1 101 101 1ff 1ff 1 1
+t2$? 1 1 1 1 3
+t2$? 1 1 7 1
+t2$? 1 3 2
+t2$? 1 3 2 2 2 1
+t2$? 1 3 2 2 3 1
+t2$? 1800 1c00 600 201 201 201 201 400
+t2$? 1800 1c0f 60f 200 200 200 400 1 1 1e01 1e00 f 100f 1800 c00 600 200
+t2$4 18 28 48 88 108 1ff 1ff 8
+t2$4 18 68 c8 188 1ff 1ff 8 8
+t2$$ 1c8 3e4 264 7ff 264 13c 38
+t2$? 1e00 1e00 7 7 4 4 1e04 1e04 4
+t2$, 1 e c
+t2$? 1f 1f
+t2$? 1f 1f 1 2 2 2 3 1
+t2$5 1f2 1e1 121 121 133 13f 1e
+t2$5 2 1e1 1e1 121 121 13f 11e
+t2$? 2 2 2 2 3
+t2$? 2 602 703 103 100 200 700 700
+t2$d 3c 7e c3 81 81 42 7ff 7ff
+t2$c 3c 7e c3 81 81 81 42
+t2$o 3c 7e c3 81 81 c3 7e 3c
+t2$e 3c 7e d3 91 91 d1 71 32
+t2$e 3c 7e d7 91 91 d1 f3 72
+t2$R 3ff 3ff 210 210 210 210 3fc 1ef 3
+t2$R 3ff 3ff 210 210 210 218 3fc 1ef 3
+t2$R 3ff 3ff 210 210 210 218 3fe 1e7 1
+t2$R 3ff 3ff 210 210 210 338 3ff 1ef 3
+t2$F 3ff 3ff 220 220 220 220 220
+t2$B 3ff 3ff 221 221 221 221 3ff 1de
+t2$R 3ff 3ff 3ff 210 210 210 3fc 1ef 3
+t2$F 3ff 3ff 3ff 220 220 220 220
+t2$? 600 600 300 100 102 102 103 303
+t2$? 600 700 100 101 202 702 702 3 3 701 700
+t2$? 600 701 102 103 203 700 700
+t2$? 601 601 307 101 100 100 100 300
+t2$? 601 601 307 101 100 100 100 300 1 2 602 702 103 103 201 700 700
+t2$? 601 601 307 101 100 100 100 300 1 3 602 702 102 102 203 701 700
+t2$i 6ff 6ff
+t2$? 700 701 3 2 2 3 1
+t2$? 701 703 2 2 703 701
+t2$s 72 f9 99 99 99 9f 4e
+t2$s 72 f9 99 99 9f 8e
+t2$s 72 f9 99 99 9f 8e 4
+t2$s 72 f9 99 99 9f e
+t2$s 72 fb 99 99 9d df 4e
+t2$, 7 6
+t2$, 7 7 6
+t2$C 78 1fe 186 303 201 201 201 201 303
+t2$0 7c fe 101 101 101 fe 7c
+t2$0 7c fe 101 101 101 fe 7e
+t2$0 7c fe 101 101 101 fe fc
+t2$0 7c fe 103 101 101 fe 7c
+t2$0 7c fe 103 101 101 fe fc
+t2$0 7c fe 181 101 101 fe 7c
+t2$0 7c fe 183 101 183 fe 7c
+t2$6 7c fe 1a1 121 121 13f 1e
+t2$6 7c fe 1a1 121 121 bf 1e
+t2$o 7e 7e 81 81 81 e7 7e 18
+t2$e 7e 7e 93 91 91 f1 72
+t2$o 7e 7e c3 81 81 e7 7e 3c
+t2$d 7e fe 81 81 81 42 7ff 7ff
+t2$d 7e ff 81 81 81 e7 7ff 7ff
+t2$o 7e ff 81 81 81 ff 7e
+t2$d 7e ff c3 81 81 c3 7ff 7ff
+t2$o 7e ff c3 81 81 c3 ff 7e
+t2$l 7ff 7ff
+t2$k 7ff 7ff 10 38 6c c6 83 1
+t2$h 7ff 7ff 40 80 80 80 ff 7f
+t2$t 80 3fe 3ff 81 81
+t2$2 81 103 107 105 10d 199 f1 e1
+t2$2 81 103 107 10f 19d 1f9 f1
+t2$2 81 3 107 10f 19d 1f9 f1
+t2$3 82 101 111 111 111 1ff ee
+t2$3 82 101 111 111 1b3 1ff ce
+t2$3 82 101 111 111 1b3 1ff ee
+t2$3 82 101 111 111 1b9 1ff ee
+t2$3 82 101 111 111 1bb 1ff ce
+t2$a 8e 9f 91 91 92 ff 7f
+t2$a 8e 9f 91 91 93 ff 7f
+t2$$ e0 1e2 132 3ff 132 13e 9c
+t2$$ e4 1f2 132 3ff 132 9e 1c
+t2$a e 5f 91 91 92 ff 7f
+t2$a e df 9b 91 d3 ff 7f
+t2$8 ee 1ef 111 111 111 1ef ee
+t2$8 ee 1ff 111 111 111 1ff ee
+t2$8 ee 1ff 191 111 111 1ff ee
+t2$9 f0 1fa 109 109 10b fe 7c
+t2$9 f2 1f9 109 109 10b fe 7c
+t2$9 f2 f9 109 109 10b fe 7c
+t2$C fc 1fe 102 201 201 201 201 201
+t2$C fc 1fe 386 303 201 201 201 301 100
+t2$C fc 1fe 387 303 201 201 201 303 303
+t3$L 1c 3e 6b 49 49 79 1a
+t3$N 1ff 1ff 111 111 111 111 1ff ee
+
+//
+// points
+//
+
+
+//
+// hash
+//
+
+h0$Ks                 0c20d41a
+h0$Kh                 10981de4
+h0$2s                 17241cda
+h0$9s                 176b7b29
+h0$4s                 1c7906a4
+h0$6h                 1d1beb9c
+h0$4c                 1e8ade9a
+h0$3d                 22b83f1b
+h0$5d                 2627cdfb
+h0$5c                 2e40bfd7
+h0$Ts                 322dfccf
+h0$2s                 3b97571f
+h0$9d                 3bda9036
+h0$7h                 3ceb7fed
+h0$8c                 43cf55cd
+h0$9h                 4b3f57c0
+h0$7s                 5069f74c
+h0$2c                 54cb21fb
+h0$8s                 59e0b504
+h0$2d                 61a9360f
+h0$Jc                 63a1257b
+h0$5s                 6520ded4
+h0$6d                 6bb58098
+h0$7d                 6e261310
+h0$3s                 7031c579
+h0$2h                 7157ef0f
+h0$5h                 730b5abf
+h0$Kc                 75f98529
+h0$3c                 774281bd
+h0$Qs                 7faf97c8
+h0$Qd                 7fefac09
+h0$Jh                 9dbd984d
+h0$Kd                 a3e62f63
+h0$8d                 a7ec7411
+h0$9c                 b2dab5e0
+h0$Th                 b65c262a
+h0$6c                 b661435b
+h0$Tc                 b969f8cd
+h0$Qh                 bf388ad7
+h0$4d                 c6dc37d3
+h0$Js                 caeaf9b0
+h0$Jd                 d0140cc3
+h0$7c                 d347e124
+h0$As                 da41c8cd
+h0$Ad                 ddc78e11
+h0$8h                 e0cbcf76
+h0$4h                 e4d43340
+h0$Ac                 ef5a8a6f
+h0$Qc                 f2233cc7
+h0$Ah                 f3568b40
+h0$Td                 f815da8b
+h0$3h                 fb7f1a29
+h0$6s                 fbd3eb13
+h0$allin              febb25e7
+
+//
+// images
+//
+
+i$2c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff8d8d8dff858585ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff5c5c5cff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffb6b6b6ff090909ff090909ff090909ff121212ff6c6c6cff858585ff858585ff
+f0f0f0fff0f0f0ff535353ff090909ff090909ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff090909ff090909ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff090909ff090909ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff090909ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff090909ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff323232ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff2a2a2aff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff535353fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff090909ff090909ff090909ff646464fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff090909ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8d8d8dff090909ff090909ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff090909ff090909ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff090909ff434343ffb6b6b6ffb6b6b6ffb6b6b6ffaeaeaeffb6b6b6ff
+f0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ffaeaeaeff323232ff434343ff434343ff4b4b4bff4b4b4bff434343ff4b4b4bff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Tc               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa6a6a6ff4b4b4bff5c5c5cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff747474ff121212ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0ff959595ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff121212fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff747474ff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff323232ff090909ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff858585ff121212ff
+f0f0f0fff0f0f0ff646464ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff
+f0f0f0fff0f0f0ff9d9d9dff4b4b4bff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Qc               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaefff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff121212ff121212ff121212ff2a2a2aff121212ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff222222ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+b6b6b6ff2a2a2aff2a2a2aff121212ff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+aeaeaeff121212ff121212ff121212ff121212ff121212ff1a1a1aff6c6c6cfff0f0f0fff0f0f0ff
+b6b6b6ff121212ff121212ff121212ff121212ff121212ff121212ff121212ff121212ffa6a6a6ff
+f0f0f0ffbebebeffb6b6b6ff222222ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff4b4b4bff121212ff2a2a2affaeaeaeff434343ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff2a2a2afff0f0f0fff0f0f0ff646464ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff3b3b3bff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff121212ff959595fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff858585fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff2a2a2aff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff5c5c5cff434343ff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$4d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7575fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffccccfdff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fdff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6e6efdff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffafafffff0000fcff0000fcff4b4bfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0505fcff0000fcff0000fafff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6262fdff0000fcff0000faff9b9bfafff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaaaafdff0000fcff0000fcff4141fafff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff0000fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3838fdff0000fcff0000fcffb6b6fbfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff9696fdff0000fcff0000fcff5b5bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffdadafdff0000feff0000fcff0000fcff4040fdff6e6efdff6161ffff6161ffff6262ffff
+f0f0f0ffa1a1fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffa9a9fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0ffc9c9fcffc9c9fcffcdcdfcffc9c9fcffcdcdfcffd0d0fbffcbcbfcffc8c8fbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffdedefeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$2s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff8d8d8dff858585ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff5c5c5cff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffb6b6b6ff090909ff090909ff090909ff121212ff6c6c6cff858585ff858585ff
+f0f0f0fff0f0f0ff535353ff090909ff090909ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff090909ff090909ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff090909ff090909ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff090909ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff090909ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff323232ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff2a2a2aff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff535353fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff090909ff090909ff090909ff646464fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff090909ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8d8d8dff090909ff090909ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff090909ff090909ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff090909ff434343ffb6b6b6ffb6b6b6ffb6b6b6ffaeaeaeffb6b6b6ff
+f0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ffaeaeaeff323232ff434343ff434343ff4b4b4bff4b4b4bff434343ff4b4b4bff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$6d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9494fdff2f2fffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb8b8fdff1515feff0000feff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ffbbbbffff0000fcff0000fcff0000fcff4e4efbff9999fcffc9c9fcff
+f0f0f0fff0f0f0fff0f0f0ff1e1efdff0000fcff0000fcffa3a3fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb0b0fdff0000fcff0000fcff9090fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4c4cfdff0000feff2f2ffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000feff0000feff9191fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffc9c9fcff0000feff0000fefff0f0f0fff0f0f0ffa6a6fdff5656fdff1f1fffff0000feff
+f0f0f0ffbbbbfcff0000feff0d0dfeffccccfdff5151feff0000feff0000feff0000feff0000feff
+f0f0f0ffb1b1fcff0000fcff0000feff0202ffff0000fcff0000feff0000fcff2f2ffcff5757fcff
+f0f0f0ff9c9cfdff0000feff0303fcff0000feff0000fcff6d6dfaffd8d8fbfff0f0f0fff0f0f0ff
+f0f0f0ff9a9afdff0000feff0000feff0000feff9898fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8dfeff0000feff0000feff6363fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8080fdff0000feff0000feffdbdbfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7979fcff0000feff2d2dfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6262fdff0000fcff5e5efbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6d6dfcff0000fcff5353fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7575fcff0000fcff3333fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9595fcff0000fcff0b0bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffc8c8fdff0000fcff0000fcffababfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0303fcff0000fcff2828fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7b7bfcff0000fcff0000fcff7f7ffffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff0000feff5858fdffbcbcfdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffc7c7fcff0000fcff0000fcff0000fcff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5353fcff0000fcff0000fcff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaaaafbff8383fcff6e6efbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Kh               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5151feff0000feff0f0ffeff1313feff0d0dfeff0000feff2626fffff0f0f0fff0f0f0ff
+f0f0f0ff2222ffff0000feff0000feff0000feff0000feff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0ffcacafdffb8b8fdff5d5dffff0000feff0000feff9f9fffffb8b8fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9191feff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ffb9b9ffff
+f0f0f0fff0f0f0fff0f0f0ff9191feff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff1313feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0000fefff0f0f0fff0f0f0ff5b5bffff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0b0bfefff0f0f0ffc6c6ffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff2020ffffdbdbffff2d2dffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000feff0b0bfeff2222ffff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0000feff0000feff0404ffff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0606ffff0000feff1b1bfffff0f0f0ff4b4bfeff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0000feffadadfffff0f0f0ffafafffff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff5d5dfffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7676ffff0000feff1717fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6f6fffff0000feff1313fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff1313fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff1717fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6262ffff0000feff1111fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+dbdbffff0000feff0000feff0000feff0000feff0000feff0000feff2626fffff0f0f0fff0f0f0ff
+c6c6ffff0000feff0000feff0000feff0000feff0000feff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0ff6d6dffff6262ffff6f6fffff7171ffff7171ffff6464ffff7474fffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$9d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feffb3b3ffffaeaefdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6ffff2222ffff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff7878fdff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff6d6dffff0000feff0000feff0909fcff8080fdffa9a9fcffa7a7fcff
+f0f0f0fff0f0f0ffd4d4fdff0000feff0000feff2727fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8686fdff0000feff0000feffc5c5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4c4cfdff0000feff2a2afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2828fdff0000feff6b6bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1616fdff0000feff8888fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0808fdff0000feff8a8afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1313feff0000feff7e7efdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3737fcff0000feff4444fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7373fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaefdff0000feff0000feff7b7bfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff0000feff9999fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9e9efdff0000feff0000feff0000feff2222ffff7474ffff7d7dffff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff7777fcff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa1a1fcff1f1ffcff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1fcffb1b1fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0b0bfefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7676fdff0000feff0000feff6e6efdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff0000feff5d5dffffb6b6ffffd5d5feffd1d1feff
+f0f0f0fff0f0f0fff0f0f0ffb8b8fdff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffcecefdff4040fdff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc5c5fcff9b9bfcff8787fcff8b8bfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$7h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7171ffff1515feff3939ffff3d3dffff4646ffff4444ffff4848fdff5858fbff
+f0f0f0fff0f0f0ff3939fcff0000fcff0000feff0000feff0000feff0000feff0000fcff0000fcff
+f0f0f0fff0f0f0ff4242fbff0000fcff2525fcff4f4ffcff4141fcff3a3afbff3232fbff3434fdff
+f0f0f0fff0f0f0ff3434fdff0000feffa5a5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1f1ffcff0000fcffa2a2fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3bfcff0000fcffa5a5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6ffff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4c4cfdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9f9fffff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5555feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaefdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7a7afdff0000feff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2222fdff0000feff2f2ffcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff6d6dfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb0b0fdff0000feff0000feffa9a9fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8686fdff0000feff0000feffd9d9fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4848fdff0000feff0000fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1fcff7575fcff9b9bfcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$7d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7171ffff1515feff3939ffff3d3dffff4646ffff4444ffff4848fdff5858fbff
+f0f0f0fff0f0f0ff3939fcff0000fcff0000feff0000feff0000feff0000feff0000fcff0000fcff
+f0f0f0fff0f0f0ff4242fbff0000fcff2525fcff4f4ffcff4141fcff3a3afbff3232fbff3434fdff
+f0f0f0fff0f0f0ff3434fdff0000feffa5a5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1f1ffcff0000fcffa2a2fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3bfcff0000fcffa5a5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6ffff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4c4cfdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9f9fffff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5555feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaefdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7a7afdff0000feff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2222fdff0000feff2f2ffcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff6d6dfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb0b0fdff0000feff0000feffa9a9fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8686fdff0000feff0000feffd9d9fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4848fdff0000feff0000fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1fcff7575fcff9b9bfcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$5c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff121212ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff535353ff7d7d7dff7d7d7dff7d7d7dff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa6a6a6ff121212ff090909fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ffaeaeaeff
+f0f0f0fff0f0f0ff9d9d9dff121212ff121212ff959595ff646464ff121212ff121212ff121212ff
+f0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff121212ff090909ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff121212ff090909ff090909ff4b4b4bff858585ff8d8d8dff
+f0f0f0fff0f0f0ff6c6c6cff090909ff121212ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff090909ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff121212ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff090909ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffa6a6a6ff090909ff121212ff222222ffbebebefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff434343ff090909ff121212ff121212ff6c6c6cff959595ff9d9d9dff9d9d9dff
+f0f0f0fff0f0f0fff0f0f0ff434343ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff1a1a1aff090909ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff8d8d8dff747474ff858585ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$3d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc9c9fcffd5d5fcffdadafdffd8d8fdffd9d9ffffd6d6fdffdadafdffdadafdff
+f0f0f0ffa0a0fdff0000fcff0000fcff0000fcff0000feff0000feff0000fcff0000fcff0000feff
+f0f0f0ff9b9bfcff0000faff0000faff0000fcff0000faff0000fcff0000faff0000faff0000fcff
+f0f0f0ff9696fbff0000faff0000faff3f3ffaff5e5efbff5454fbff5050fbff4e4efbff5a5afbff
+f0f0f0ff9494fbff0000faff0000fcffcdcdfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8b8bfcff0000faff0000faffbbbbfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffa7a7fcff0000faff0000f8ffd0d0fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5d5dfcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9a9afdff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9a9afdff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0fdff0000fcff0000fcff0000fcff0000faff4141faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2626fbff0000faff9494fbfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc6c6fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7474fdff0000feff9d9dfffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff0000fcff0000fcff0000fcffd4d4fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffafaffcff0000fcff0000fcff0202fdffd6d6fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff5d5dfcff0000fcff0000fcff0000feff8282fdffd6d6fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6161fcff0000fcff0000fcff0000fcff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9f9ffcff0000fcff0000fcff0000fcff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff6d6dfcff4e4efbff4545fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Kc               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff4b4b4bff121212ff1a1a1aff1a1a1aff1a1a1aff121212ff2a2a2afff0f0f0fff0f0f0ff
+f0f0f0ff2a2a2aff121212ff121212ff121212ff121212ff121212ff121212fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff9d9d9dff535353ff121212ff121212ff8d8d8dff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff1a1a1aff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0ff535353ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0ffaeaeaeff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff2a2a2affb6b6b6ff323232ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1aff2a2a2aff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff222222fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff959595fff0f0f0ff959595ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff535353fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff646464ff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+b6b6b6ff121212ff121212ff121212ff121212ff121212ff121212ff2a2a2afff0f0f0fff0f0f0ff
+aeaeaeff121212ff121212ff121212ff121212ff121212ff121212ff121212fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff5c5c5cff646464ff646464ff646464ff5c5c5cff6c6c6cfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Kd               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5151feff0000feff0f0ffeff1313feff0d0dfeff0000feff2626fffff0f0f0fff0f0f0ff
+f0f0f0ff2222ffff0000feff0000feff0000feff0000feff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0ffcacafdffb8b8fdff5d5dffff0000feff0000feff9f9fffffb8b8fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9191feff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ffb9b9ffff
+f0f0f0fff0f0f0fff0f0f0ff9191feff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff1313feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0000fefff0f0f0fff0f0f0ff5b5bffff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff0b0bfefff0f0f0ffc6c6ffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff2020ffffdbdbffff2d2dffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000feff0b0bfeff2222ffff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0000feff0000feff0404ffff0000feff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0606ffff0000feff1b1bfffff0f0f0ff4b4bfeff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0000feffadadfffff0f0f0ffafafffff
+f0f0f0fff0f0f0fff0f0f0ff8f8ffeff0000feff0000feff5d5dfffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7676ffff0000feff1717fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6f6fffff0000feff1313fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8888ffff0000feff1313fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8686ffff0000feff1717fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6262ffff0000feff1111fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+dbdbffff0000feff0000feff0000feff0000feff0000feff0000feff2626fffff0f0f0fff0f0f0ff
+c6c6ffff0000feff0000feff0000feff0000feff0000feff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0ff6d6dffff6262ffff6f6fffff7171ffff7171ffff6464ffff7474fffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Jh               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1717feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9090fdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd3d3feffdbdbfffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7f7fffff0000feff0000feffc4c4fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7272ffff0000feff0000feffbebefdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6666ffff0000feff0000feffb3b3fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8888ffff0000feff0000feff7979fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6ffff0000feff0000feff0000feffc4c4fffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1111feff0000feff0000feff0000feff7272ffff9f9fffff9999ffff6161ffff
+f0f0f0fff0f0f0ffa6a6ffff0000feff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ffb1b1ffff3d3dffff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc2c2fdffa8a8fdffbdbdfffff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$8c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff9d9d9dff7d7d7dff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff747474ff090909ff121212ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff4b4b4bff090909ff090909ff090909ff2a2a2aff323232ff
+f0f0f0fff0f0f0ffc7c7c7ff747474ff121212ff121212ff646464ff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff121212ff1a1a1aff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff8d8d8dff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff7d7d7dff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff747474ff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff8d8d8dff121212ff323232ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff090909ff121212ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff7d7d7dff090909ff121212ff4b4b4bffa6a6a6ff9d9d9dfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff858585ff090909ff090909ff121212ff121212ff090909ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff7d7d7dff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffc7c7c7ff5c5c5cff121212ff090909ff1a1a1aff646464ff9d9d9dffa6a6a6ff
+f0f0f0ffcfcfcfff7d7d7dff090909ff090909ff4b4b4bffa6a6a6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff121212ff090909ff323232ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff959595ff090909ff222222ff858585fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8d8dff121212ff2a2a2affaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff1a1a1aff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff323232ff121212ff2a2a2aff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff9d9d9dff090909ff090909ff222222ff8d8d8dff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff7d7d7dff090909ff121212ff121212ff121212ff2a2a2aff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff959595ff121212ff090909ff121212ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff858585ff4b4b4bff323232ff2a2a2aff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Td               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc2c2fdff4f4ffeff6161fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8585fcff0000feff0000feffd9d9fcfff0f0f0fff0f0f0fff0f0f0ffafafffff
+f0f0f0fff0f0f0ff8f8ffcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ffc8c8fdff0000feff
+f0f0f0fff0f0f0ff8989fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff5454fdff0000fcff
+f0f0f0fff0f0f0ff8787fcff0000fcff0000fefff0f0f0fff0f0f0fff0f0f0ff2020fdff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8c8cfdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8b8bfcff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8888ffff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8888fdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8989fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8787fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8282fdff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8585fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8484fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8383fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8383fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff7d7dfcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff3030fdff0000fcff
+f0f0f0fff0f0f0ff7676fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff9b9bfcff0000feff
+f0f0f0fff0f0f0ff6c6cfdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5656fdff
+f0f0f0fff0f0f0ffb8b8fdff4c4cfdff7f7ffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$3c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaeaeffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff121212ff121212ff090909ff090909ff121212ff
+f0f0f0ff858585ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff858585ff090909ff090909ff3b3b3bff535353ff4b4b4bff4b4b4bff4b4b4bff535353ff
+f0f0f0ff858585ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff090909ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8d8dff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7d7d7dff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff090909ff090909ff090909ff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff090909ff858585fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff090909ff090909ff090909ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff959595ff090909ff090909ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff535353ff090909ff090909ff121212ff747474ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff090909ff090909ff090909ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff646464ff4b4b4bff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Ts               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa6a6a6ff4b4b4bff5c5c5cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff747474ff121212ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0ff959595ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff121212fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff747474ff121212ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff121212ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff747474ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff
+f0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff323232ff090909ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff858585ff121212ff
+f0f0f0fff0f0f0ff646464ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff
+f0f0f0fff0f0f0ff9d9d9dff4b4b4bff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$6c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff323232ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff222222ff121212ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff090909ff090909ff090909ff4b4b4bff858585ffaeaeaeff
+f0f0f0fff0f0f0fff0f0f0ff222222ff090909ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff959595ff090909ff090909ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4b4b4bff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff121212ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff121212ff121212fff0f0f0fff0f0f0ff8d8d8dff535353ff222222ff121212ff
+f0f0f0ff9d9d9dff121212ff1a1a1affaeaeaeff4b4b4bff121212ff121212ff121212ff121212ff
+f0f0f0ff959595ff090909ff121212ff121212ff090909ff121212ff090909ff323232ff535353ff
+f0f0f0ff858585ff121212ff121212ff121212ff090909ff646464ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0ff858585ff121212ff121212ff121212ff858585fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff121212ff121212ff5c5c5cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff747474ff121212ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff090909ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff090909ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff858585ff090909ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff090909ff959595fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff090909ff090909ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff090909ff090909ff121212ff535353ff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff090909ff090909ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff090909ff090909ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff747474ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$2s               10  40 
+c9e0d8ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ff
+c9e0d9ffc9e0d8ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ff849b94ff768d86ff708780ff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ff9fb6afff4d645dff081f18ff081f18ff081f18ff081f18ff
+c9e0d9ffc9e0d9ffc9e0d9ff7d948dff081f18ff081f18ff081f18ff082018ff081f18ff082018ff
+c9e0d9ffc9e0d9ff99b0a9ff081f18ff081f18ff081f18ff0f271fff5b736bff708880ff708881ff
+c9e0d9ffc9e0d9ff465d56ff081f18ff081f18ff384f48ffc9e1d9ffc9e0d9ffc9e0d9ffc9e1d9ff
+c9e0d9ffc9e0d9ff081f18ff081f18ff162d26ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e1daff
+c9e0d9ff99b0a9ff081f18ff081f18ff546b64ffc9e1d9ffc9e0d9ffc9e1d9ffc9e1daffc9e1daff
+c9e0d9ff99b0a9ff081f18ff081f18ff3f5750ffc9e0d9ffc9e1d9ffc9e1daffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ff1d342dff081f18ff5b736bffc9e1daffc9e1daffc9e1daffc9e1d9ffc9e1daff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daff3f5750ff
+c9e0d9ffc9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1d9ff99b1a9ff2a423bff082019ff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1daffc9e1daff768e86ff082019ff082019ff082019ff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ffc9e1daff708881ff082018ff082019ff082019ff233b34ff
+c9e0d9ffc9e0d9ffc9e0d9ffc9e1d9ff768e87ff082019ff082018ff082019ff465e57ffc9e1daff
+c9e0d9ffc9e0d9ffc9e1d9ff849c94ff082018ff082019ff082019ff546c65ffc9e1daffc9e1daff
+c9e0d9ffc9e0d9ffc9e1d9ff1d352dff082018ff082019ff3f5750ffc9e1d9ffc9e1d9ffc9e1daff
+c9e0d9ffc9e0d9ff768e86ff082018ff082018ff1d352effc9e1daffc9e1d9ffc9e1d9ffc9e1daff
+c9e0d9ffc9e0d9ff324a42ff082018ff082018ff768e86ffc9e1daffc9e1daffc9e1d9ffc9e1daff
+c9e0d9ffc9e0d9ff082018ff082019ff2a423affc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daff
+c9e0d9ff92a9a2ff082018ff082018ff385048ff99b1a9ff99b1aaff99b1aaff92aaa3ff99b1aaff
+c9e0d9ff7d958dff082018ff082018ff082018ff082018ff082019ff082019ff082019ff082019ff
+c9e0d9ff768e86ff082018ff082018ff082018ff082018ff082018ff082019ff082019ff082019ff
+c9e0d9ff92a9a2ff2a423aff385048ff385048ff3f574fff3f574fff385049ff3f5750ff3f5750ff
+c9e0d9ffc9e1d9ffc9e1daffc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daffc9e1daffc9e1daff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daffc9e1daffc9e1daff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daffc9e1daffb6cec7ff526a63ff
+c9e0d9ffc9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daffc9e1daff718982ff001811ff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daffc9e1daffc9e1daff2c443dff001811ff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daffc9e1daff6b837cff001811ff001811ff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daff91a9a2ff0f2720ff001811ff001811ff
+c9e0d9ffc9e1d9ffc9e1d9ffc9e1d9ffc9e1daffc9e1daff344c45ff021a13ff001811ff001811ff
+c9e0d9ffc9e0d9ffc9e1daffc9e1daffc9e1daff6f8780ff041c15ff001811ff001811ff001811ff
+c9e1d9ffc9e1d9ffc9e1d9ffc9e1daff9fb8b0ff122b23ff001811ff001811ff001811ff001811ff
+c9e1d9ffc9e1d9ffc9e1d9ffc9e1daff3d554eff001811ff001811ff001811ff001811ff001811ff
+c9e1d9ffc9e1d9ffc9e1daff8ba39cff0c241dff001811ff001811ff001811ff001811ff001811ff
+i$6h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9494fdff2f2fffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb8b8fdff1515feff0000feff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ffbbbbffff0000fcff0000fcff0000fcff4e4efbff9999fcffc9c9fcff
+f0f0f0fff0f0f0fff0f0f0ff1e1efdff0000fcff0000fcffa3a3fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb0b0fdff0000fcff0000fcff9090fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4c4cfdff0000feff2f2ffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000feff0000feff9191fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffc9c9fcff0000feff0000fefff0f0f0fff0f0f0ffa6a6fdff5656fdff1f1fffff0000feff
+f0f0f0ffbbbbfcff0000feff0d0dfeffccccfdff5151feff0000feff0000feff0000feff0000feff
+f0f0f0ffb1b1fcff0000fcff0000feff0202ffff0000fcff0000feff0000fcff2f2ffcff5757fcff
+f0f0f0ff9c9cfdff0000feff0303fcff0000feff0000fcff6d6dfaffd8d8fbfff0f0f0fff0f0f0ff
+f0f0f0ff9a9afdff0000feff0000feff0000feff9898fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8dfeff0000feff0000feff6363fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8080fdff0000feff0000feffdbdbfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7979fcff0000feff2d2dfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6262fdff0000fcff5e5efbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6d6dfcff0000fcff5353fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7575fcff0000fcff3333fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9595fcff0000fcff0b0bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffc8c8fdff0000fcff0000fcffababfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0303fcff0000fcff2828fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7b7bfcff0000fcff0000fcff7f7ffffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff0000feff5858fdffbcbcfdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffc7c7fcff0000fcff0000fcff0000fcff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5353fcff0000fcff0000fcff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaaaafbff8383fcff6e6efbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$Th               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc2c2fdff4f4ffeff6161fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8585fcff0000feff0000feffd9d9fcfff0f0f0fff0f0f0fff0f0f0ffafafffff
+f0f0f0fff0f0f0ff8f8ffcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ffc8c8fdff0000feff
+f0f0f0fff0f0f0ff8989fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff5454fdff0000fcff
+f0f0f0fff0f0f0ff8787fcff0000fcff0000fefff0f0f0fff0f0f0fff0f0f0ff2020fdff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8c8cfdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8b8bfcff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8888ffff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8989fcff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8a8afdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8888fdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8989fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000feff
+f0f0f0fff0f0f0ff8787fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8282fdff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8585fcff0000fcff0000fcfff0f0f0fff0f0f0fff0f0f0ff0000feff0000fcff
+f0f0f0fff0f0f0ff8484fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff8383fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff
+f0f0f0fff0f0f0ff8383fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0ff7d7dfcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff3030fdff0000fcff
+f0f0f0fff0f0f0ff7676fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff9b9bfcff0000feff
+f0f0f0fff0f0f0ff6c6cfdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5656fdff
+f0f0f0fff0f0f0ffb8b8fdff4c4cfdff7f7ffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$Js               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff747474ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff121212ff121212ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff121212ff121212ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9d9d9dff121212ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1a1a1aff121212ff121212ff121212ff6c6c6cff8d8d8dff858585ff5c5c5cff
+f0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff959595ff3b3b3bff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff959595ffa6a6a6fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$9c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff9d9d9dff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff2a2a2aff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff646464ff121212ff121212ff121212ff747474ff959595ff8d8d8dff
+f0f0f0fff0f0f0ffb6b6b6ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff747474ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4b4b4bff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2a2a2aff121212ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff121212ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff121212ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1a1a1aff121212ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff121212ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff959595ff121212ff121212ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff121212ff858585fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff2a2a2aff6c6c6cff6c6c6cff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff222222ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff121212ff535353ff9d9d9dffb6b6b6ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff434343ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff858585ff747474ff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$8s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff9d9d9dff7d7d7dff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff747474ff090909ff121212ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff4b4b4bff090909ff090909ff090909ff2a2a2aff323232ff
+f0f0f0fff0f0f0ffc7c7c7ff747474ff121212ff121212ff646464ff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff121212ff1a1a1aff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff8d8d8dff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff7d7d7dff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff747474ff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff8d8d8dff121212ff323232ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff090909ff121212ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff7d7d7dff090909ff121212ff4b4b4bffa6a6a6ff9d9d9dfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff858585ff090909ff090909ff121212ff121212ff090909ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff7d7d7dff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffc7c7c7ff5c5c5cff121212ff090909ff1a1a1aff646464ff9d9d9dffa6a6a6ff
+f0f0f0ffcfcfcfff7d7d7dff090909ff090909ff4b4b4bffa6a6a6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff121212ff090909ff323232ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff959595ff090909ff222222ff858585fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8d8dff121212ff2a2a2affaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff1a1a1aff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff323232ff121212ff2a2a2aff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcfcfff9d9d9dff090909ff090909ff222222ff8d8d8dff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc7c7c7ff7d7d7dff090909ff121212ff121212ff121212ff2a2a2aff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff959595ff121212ff090909ff121212ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff858585ff4b4b4bff323232ff2a2a2aff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$Jc               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff747474ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff121212ff121212ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff121212ff121212ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9d9d9dff121212ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1a1a1aff121212ff121212ff121212ff6c6c6cff8d8d8dff858585ff5c5c5cff
+f0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff959595ff3b3b3bff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff959595ffa6a6a6fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$2d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbcbcfdffa1a1fcff9999fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffe0e0fdff6161fcff0000fcff0000faff0000faff0000faff
+f0f0f0fff0f0f0fff0f0f0ffababfcff0000fcff0000faff0000f8ff0000f8ff0000faff0000faff
+f0f0f0fff0f0f0ffd3d3fcff0000faff0000faff0000f8ff0b0bf8ff7575f8ff9a9af9ff9b9bf8ff
+f0f0f0fff0f0f0ff5c5cfbff0000f8ff0000f8ff4646f7fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000faff0000faff1515f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffd3d3fcff0000f8ff0000f8ff7272f9fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffd9d9fcff0000f8ff0000f8ff4d4dfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2121f8ff0000f8ff7777f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4f4ffcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd6d6fdff2f2ffcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9dfcff0000fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff0000fcff0000faff0000faff2727f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9e9efdff0000faff0000faff0000fcff5757f8fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffb9b9fcff0000fcff0000f8ff0000f8ff6b6bf8fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1919fcff0000fcff0000faff4f4ff6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa3a3fcff0000f8ff0000faff1b1bf8fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3c3cfbff0000f8ff0000faffa8a8f9fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000fcff0000faff2c2cfbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcffcff0000faff0000fcff4141fcffdbdbfcffd6d6fdffd4d4fdffd0d0fdffd2d2fdff
+f0f0f0ffaeaefdff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffa6a6fdff0000fcff0000fcff0000fcff0000faff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffc9c9fcff3434fbff4545faff4b4bf8ff4d4df8ff5050fbff4949fcff4d4dfaff4e4efbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$8d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb9b9f4ffb8b8fdff8d8dfeff9191fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc8c8f3ff8888fdff0000fcff0000feff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0ffd0d0f2ff5050fdff0000fcff0000fcff0000faff2222f9ff3333faff
+f0f0f0fff0f0f0ffdcdcf1ff8484ffff0000feff0404fbff6e6ef9ffafaff8fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdadaf1ff0000feff1313fcff6e6efafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffa4a4fdff0000feff3131fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff8a8afdff0000feff3838fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff8888fdff0000feff3131fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffa3a3fcff0000feff2d2dfcffb2b2fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdadaf1ff0000fcff0606fdff5050fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdcdcf1ff8989fcff0000fcff0101fcff4d4dfeffc4c4ffffb0b0f8fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ff9696fbff0000fcff0000fcff0000feff0000feff0000fcff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ff8f8ffeff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0ffdbdbf1ff5f5fffff0000feff0000fcff1111fcff6f6ffaffb5b5faffc3c3faff
+f0f0f0ffe6e6f1ff8e8efdff0000fcff0000fcff4e4efbffc0c0fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff0707fcff0000fcff3535faffc7c7fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb0b0fdff0000fcff1818fbff9191f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8dfcff0000fcff2424fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8989fcff0000fcff2424fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9f9ffcff0000feff2525fcffc4c4fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcecefdff0000fcff1313fcff7d7dfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff2d2dfcff0000feff2626fdffa1a1fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffb3b3fcff0000fcff0000fcff1616fdff9d9dffffb1b1f9fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdcdcf1ff9191fcff0000fcff0000feff0000feff0000feff2020ffff4d4dfeff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ffa9a9fcff0303fcff0000fcff0000feff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebef4ff9b9bfcff5151fcff2e2efbff2424fbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Qs               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaefff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff121212ff121212ff121212ff2a2a2aff121212ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff222222ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff222222ff121212ff3b3b3bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+b6b6b6ff2a2a2aff2a2a2aff121212ff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+aeaeaeff121212ff121212ff121212ff121212ff121212ff1a1a1aff6c6c6cfff0f0f0fff0f0f0ff
+b6b6b6ff121212ff121212ff121212ff121212ff121212ff121212ff121212ff121212ffa6a6a6ff
+f0f0f0ffbebebeffb6b6b6ff222222ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff4b4b4bff121212ff2a2a2affaeaeaeff434343ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff2a2a2afff0f0f0fff0f0f0ff646464ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff3b3b3bff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff121212ff959595fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff858585fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff2a2a2aff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff5c5c5cff434343ff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$As               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff818181ff343434ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9c9cff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff707070ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff323232ff222222ff3e3e3eff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff2c2c2cffb1b1b1ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff222222ff494949fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7b7b7bff222222ff727272fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff404040ff222222ff8d8d8dfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ffb1b1b1fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbfbfbfff222222ff222222fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9c9cff222222ff2c2c2cfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff757575ff222222ff656565fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff373737ff222222ff969696fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ffc0c0c0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1b1ff222222ff222222fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff898989ff222222ff222222ff636363ff696969ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff565656ff222222ff222222ff222222ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ff464646ff5c5c5cff545454ff535353ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff222222ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff989898ff222222ff272727fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6d6d6dff222222ff505050fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff929292ff3d3d3dff222222ff222222ff2c2c2cff848484ffc4c4c4fff0f0f0fff0f0f0ff
+f0f0f0ff616161ff222222ff222222ff222222ff222222ff222222ff909090fff0f0f0fff0f0f0ff
+f0f0f0ffcacacaffadadadffb0b0b0ffaeaeaeffaeaeaeffaaaaaaffcfcfcffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$Jd               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1717feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9090fdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd3d3feffdbdbfffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7f7fffff0000feff0000feffc4c4fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7272ffff0000feff0000feffbebefdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6666ffff0000feff0000feffb3b3fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8888ffff0000feff0000feff7979fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6ffff0000feff0000feff0000feffc4c4fffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1111feff0000feff0000feff0000feff7272ffff9f9fffff9999ffff6161ffff
+f0f0f0fff0f0f0ffa6a6ffff0000feff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ffb1b1ffff3d3dffff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc2c2fdffa8a8fdffbdbdfffff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$4s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff323232ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff646464ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff090909fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5c5c5cff090909ff090909ff858585fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff434343fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3b3b3bff090909ff090909ff9d9d9dfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff858585ff090909ff090909ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff121212ff090909ff090909ff434343ff646464ff5c5c5cff5c5c5cff5c5c5cff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$4c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff323232ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff646464ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff090909ff090909fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5c5c5cff090909ff090909ff858585fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff090909ff090909ff434343fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff090909ff090909ff090909fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3b3b3bff090909ff090909ff9d9d9dfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff858585ff090909ff090909ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb6b6b6ff121212ff090909ff090909ff434343ff646464ff5c5c5cff5c5c5cff5c5c5cff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff959595ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0ffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeffaeaeaeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$4h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7575fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffccccfdff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fdff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6e6efdff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffafafffff0000fcff0000fcff4b4bfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0505fcff0000fcff0000fafff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6262fdff0000fcff0000faff9b9bfafff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaaaafdff0000fcff0000fcff4141fafff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcff0000fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3838fdff0000fcff0000fcffb6b6fbfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff9696fdff0000fcff0000fcff5b5bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffdadafdff0000feff0000fcff0000fcff4040fdff6e6efdff6161ffff6161ffff6262ffff
+f0f0f0ffa1a1fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffa9a9fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0ffc9c9fcffc9c9fcffcdcdfcffc9c9fcffcdcdfcffd0d0fbffcbcbfcffc8c8fbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffdedefeff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$7c               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff646464ff222222ff3b3b3bff3b3b3bff434343ff434343ff434343ff535353ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff121212ff121212ff121212ff121212ff090909ff090909ff
+f0f0f0fff0f0f0ff434343ff090909ff2a2a2aff4b4b4bff434343ff3b3b3bff323232ff323232ff
+f0f0f0fff0f0f0ff323232ff121212ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff121212ff323232ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff121212ff121212ff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff434343ff121212ff090909fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff6c6c6cff858585fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Ac               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff818181ff343434ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9c9cff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff707070ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff323232ff222222ff3e3e3eff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff2c2c2cffb1b1b1ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff222222ff494949fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7b7b7bff222222ff727272fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff404040ff222222ff8d8d8dfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ffb1b1b1fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbfbfbfff222222ff222222fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9c9cff222222ff2c2c2cfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff757575ff222222ff656565fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff373737ff222222ff969696fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ffc0c0c0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1b1ff222222ff222222fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff898989ff222222ff222222ff636363ff696969ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff565656ff222222ff222222ff222222ff222222ff222222ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff222222ff222222ff464646ff5c5c5cff545454ff535353ff
+f0f0f0fff0f0f0fff0f0f0ffbebebeff222222ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff989898ff222222ff272727fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6d6d6dff222222ff505050fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff929292ff3d3d3dff222222ff222222ff2c2c2cff848484ffc4c4c4fff0f0f0fff0f0f0ff
+f0f0f0ff616161ff222222ff222222ff222222ff222222ff222222ff909090fff0f0f0fff0f0f0ff
+f0f0f0ffcacacaffadadadffb0b0b0ffaeaeaeffaeaeaeffaaaaaaffcfcfcffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3c3ff3e3e3eff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa0a0a0ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0d0ff454545ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb5b5b5ff111111ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb2b2b2ff0b0b0bff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc4c4c4ff2e2e2eff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffeeeeeeff7f7f7fff000000ff000000ff000000ff
+f0f0f0fff0f0f0ffe6e6e6ff979797ff858585ffbbbbbbffdededeff4c4c4cff000000ff000000ff
+f0f0f0ffe0e0e0ff1d1d1dff000000ff000000ff000000ff2f2f2fff7d7d7dff1c1c1cff000000ff
+i$Ad               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7979ffff1717feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffcecefdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9b9bffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6464ffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1515feff0000feff2424fdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0e0efdffb7b7fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa8a8fdff0000feff3333fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7171ffff0000feff6767fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2626ffff0000feff8989fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feffb7b7fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc8c8fdff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9cfdff0000feff0e0efdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6a6afdff0000feff5656fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1b1bffff0000feff9494fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feffcacafdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8383ffff0000feff0000feff5353feff5b5bffff5555feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff4242ffff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff2e2efdff4a4afdff4040fdff3f3ffcff
+f0f0f0fff0f0f0fff0f0f0ffc6c6ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9797feff0000feff0707fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff3b3bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8f8ffeff2222ffff0000feff0000feff0d0dfeff7d7dffffcecefdfff0f0f0fff0f0f0ff
+f0f0f0ff5151feff0000feff0000feff0000feff0000feff0000feff8c8cfdfff0f0f0fff0f0f0ff
+f0f0f0ffd6d6fdffb2b2fdffb5b5fcffb3b3fcffb3b3fcffaeaefdffdcdcfdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$5h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffccccfdffd6d6fdffd8d8fdffd2d2fdffd7d7feffd7d7feff
+f0f0f0fff0f0f0fff0f0f0ff2e2efdff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff1414fdff0000feff0000feff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff5d5dfcff9191fcff8a8afbff8d8dfcff8f8ffcff
+f0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcffc9c9fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd1d1fcff0000fcff0000fcffcfcffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc4c4fdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ffd5d5feffcfcffeff
+f0f0f0fff0f0f0ffb4b4fdff0000feff0000feffa8a8fdff6f6fffff0000feff0000feff0000feff
+f0f0f0fff0f0f0ffa2a2fdff0000feff0000feff0000feff0000feff0000fcff0000feff0000feff
+f0f0f0fff0f0f0ff9292fbff0000fcff0000feff0000fcff0000fcff4b4bfcff9797fcffa7a7fcff
+f0f0f0fff0f0f0ff7979fcff0000fcff0000feff4b4bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7878fdff0000fcff4444fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffbbbbfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd1d1fefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6262fdff0000feff4c4cfdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6e6efdff0000fcff0000feffc6c6fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffbfbffcff0000fcff0000feff1717feffddddfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4141fcff0000fcff0000feff0000feff7474ffffacacfdffb6b6ffffb6b6ffff
+f0f0f0fff0f0f0fff0f0f0ff3f3ffcff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff0b0bfcff0000fcff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbfbffcff9d9dfcff8888fbff9797fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$2h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbcbcfdffa1a1fcff9999fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffe0e0fdff6161fcff0000fcff0000faff0000faff0000faff
+f0f0f0fff0f0f0fff0f0f0ffababfcff0000fcff0000faff0000f8ff0000f8ff0000faff0000faff
+f0f0f0fff0f0f0ffd3d3fcff0000faff0000faff0000f8ff0b0bf8ff7575f8ff9a9af9ff9b9bf8ff
+f0f0f0fff0f0f0ff5c5cfbff0000f8ff0000f8ff4646f7fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000faff0000faff1515f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffd3d3fcff0000f8ff0000f8ff7272f9fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffd9d9fcff0000f8ff0000f8ff4d4dfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2121f8ff0000f8ff7777f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4f4ffcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd6d6fdff2f2ffcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9dfcff0000fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff0000fcff0000faff0000faff2727f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9e9efdff0000faff0000faff0000fcff5757f8fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffb9b9fcff0000fcff0000f8ff0000f8ff6b6bf8fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1919fcff0000fcff0000faff4f4ff6fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa3a3fcff0000f8ff0000faff1b1bf8fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3c3cfbff0000f8ff0000faffa8a8f9fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0000fcff0000faff2c2cfbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcfcffcff0000faff0000fcff4141fcffdbdbfcffd6d6fdffd4d4fdffd0d0fdffd2d2fdff
+f0f0f0ffaeaefdff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffa6a6fdff0000fcff0000fcff0000fcff0000faff0000fcff0000fcff0000fcff0000fcff
+f0f0f0ffc9c9fcff3434fbff4545faff4b4bf8ff4d4df8ff5050fbff4949fcff4d4dfaff4e4efbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$5s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0ff323232ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff1a1a1aff121212ff121212ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff535353ff7d7d7dff7d7d7dff7d7d7dff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffa6a6a6ff121212ff090909fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ffaeaeaeff
+f0f0f0fff0f0f0ff9d9d9dff121212ff121212ff959595ff646464ff121212ff121212ff121212ff
+f0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff121212ff090909ff121212ff121212ff
+f0f0f0fff0f0f0ff7d7d7dff090909ff121212ff090909ff090909ff4b4b4bff858585ff8d8d8dff
+f0f0f0fff0f0f0ff6c6c6cff090909ff121212ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff090909ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff121212ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff090909ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffa6a6a6ff090909ff121212ff222222ffbebebefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff434343ff090909ff121212ff121212ff6c6c6cff959595ff9d9d9dff9d9d9dff
+f0f0f0fff0f0f0fff0f0f0ff434343ff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff1a1a1aff090909ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff8d8d8dff747474ff858585ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$3h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc9c9fcffd5d5fcffdadafdffd8d8fdffd9d9ffffd6d6fdffdadafdffdadafdff
+f0f0f0ffa0a0fdff0000fcff0000fcff0000fcff0000feff0000feff0000fcff0000fcff0000feff
+f0f0f0ff9b9bfcff0000faff0000faff0000fcff0000faff0000fcff0000faff0000faff0000fcff
+f0f0f0ff9696fbff0000faff0000faff3f3ffaff5e5efbff5454fbff5050fbff4e4efbff5a5afbff
+f0f0f0ff9494fbff0000faff0000fcffcdcdfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8b8bfcff0000faff0000faffbbbbfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffa7a7fcff0000faff0000f8ffd0d0fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5d5dfcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8dfeff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9a9afdff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9a9afdff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd0d0fdff0000fcff0000fcff0000fcff0000faff4141faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2626fbff0000faff9494fbfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc6c6fffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7474fdff0000feff9d9dfffff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff0000fcff0000fcff0000fcffd4d4fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffafaffcff0000fcff0000fcff0202fdffd6d6fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff5d5dfcff0000fcff0000fcff0000feff8282fdffd6d6fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6161fcff0000fcff0000fcff0000fcff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9f9ffcff0000fcff0000fcff0000fcff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff6d6dfcff4e4efbff4545fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$3s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaeaeffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ffb6b6b6ff
+f0f0f0ff8d8d8dff090909ff090909ff090909ff121212ff121212ff090909ff090909ff121212ff
+f0f0f0ff858585ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff090909ff
+f0f0f0ff858585ff090909ff090909ff3b3b3bff535353ff4b4b4bff4b4b4bff4b4b4bff535353ff
+f0f0f0ff858585ff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff090909ff090909ff9d9d9dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8d8dff090909ff090909ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7d7d7dff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff090909ff090909ff090909ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff090909ff090909ff090909ff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff090909ff858585fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaeaefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff090909ff090909ff090909ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff959595ff090909ff090909ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff535353ff090909ff090909ff121212ff747474ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff090909ff090909ff090909ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff090909ff090909ff090909ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff646464ff4b4b4bff434343ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$8h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb9b9f4ffb8b8fdff8d8dfeff9191fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc8c8f3ff8888fdff0000fcff0000feff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0ffd0d0f2ff5050fdff0000fcff0000fcff0000faff2222f9ff3333faff
+f0f0f0fff0f0f0ffdcdcf1ff8484ffff0000feff0404fbff6e6ef9ffafaff8fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdadaf1ff0000feff1313fcff6e6efafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffa4a4fdff0000feff3131fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff8a8afdff0000feff3838fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff8888fdff0000feff3131fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffa3a3fcff0000feff2d2dfcffb2b2fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdadaf1ff0000fcff0606fdff5050fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdcdcf1ff8989fcff0000fcff0101fcff4d4dfeffc4c4ffffb0b0f8fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ff9696fbff0000fcff0000fcff0000feff0000feff0000fcff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ff8f8ffeff0000fcff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0ffdbdbf1ff5f5fffff0000feff0000fcff1111fcff6f6ffaffb5b5faffc3c3faff
+f0f0f0ffe6e6f1ff8e8efdff0000fcff0000fcff4e4efbffc0c0fafff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff0707fcff0000fcff3535faffc7c7fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffb0b0fdff0000fcff1818fbff9191f8fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8d8dfcff0000fcff2424fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8989fcff0000fcff2424fafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff9f9ffcff0000feff2525fcffc4c4fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffcecefdff0000fcff1313fcff7d7dfafff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ff2d2dfcff0000feff2626fdffa1a1fafff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffe6e6f1ffb3b3fcff0000fcff0000fcff1616fdff9d9dffffb1b1f9fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffdcdcf1ff9191fcff0000fcff0000feff0000feff0000feff2020ffff4d4dfeff
+f0f0f0fff0f0f0fff0f0f0ffd2d2f2ffa9a9fcff0303fcff0000fcff0000feff0000fcff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebef4ff9b9bfcff5151fcff2e2efbff2424fbff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$7s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff646464ff222222ff3b3b3bff3b3b3bff434343ff434343ff434343ff535353ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff121212ff121212ff121212ff121212ff090909ff090909ff
+f0f0f0fff0f0f0ff434343ff090909ff2a2a2aff4b4b4bff434343ff3b3b3bff323232ff323232ff
+f0f0f0fff0f0f0ff323232ff121212ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff535353ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff090909ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2a2a2aff121212ff323232ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff121212ff121212ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff121212ff121212ff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff434343ff121212ff090909fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff6c6c6cff858585fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$5d               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffccccfdffd6d6fdffd8d8fdffd2d2fdffd7d7feffd7d7feff
+f0f0f0fff0f0f0fff0f0f0ff2e2efdff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff1414fdff0000feff0000feff0000fcff0000fcff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff5d5dfcff9191fcff8a8afbff8d8dfcff8f8ffcff
+f0f0f0fff0f0f0fff0f0f0ff0000fcff0000fcffc9c9fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd1d1fcff0000fcff0000fcffcfcffcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffc4c4fdff0000feff0000fcfff0f0f0fff0f0f0fff0f0f0ffd5d5feffcfcffeff
+f0f0f0fff0f0f0ffb4b4fdff0000feff0000feffa8a8fdff6f6fffff0000feff0000feff0000feff
+f0f0f0fff0f0f0ffa2a2fdff0000feff0000feff0000feff0000feff0000fcff0000feff0000feff
+f0f0f0fff0f0f0ff9292fbff0000fcff0000feff0000fcff0000fcff4b4bfcff9797fcffa7a7fcff
+f0f0f0fff0f0f0ff7979fcff0000fcff0000feff4b4bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7878fdff0000fcff4444fbfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffbbbbfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffd1d1fefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6262fdff0000feff4c4cfdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6e6efdff0000fcff0000feffc6c6fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffbfbffcff0000fcff0000feff1717feffddddfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4141fcff0000fcff0000feff0000feff7474ffffacacfdffb6b6ffffb6b6ffff
+f0f0f0fff0f0f0fff0f0f0ff3f3ffcff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9999fcff0b0bfcff0000fcff0000fcff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffbfbffcff9d9dfcff8888fbff9797fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Qd               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffcdcdfefff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5757feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff1717feff0000feff0000feff0000feff2424fdff0808ffff
+f0f0f0fff0f0f0fff0f0f0ffa0a0fdff0000feff0000feff1919fcffd7d7fcfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff0000feffc1c1fcfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff0a0afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1717feff0000feff2b2bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0808ffff0000feff2121fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0202ffff0000feff2626fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff3b3bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0606ffff0000feff3d3dfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0f0ffeff0000feff3a3afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1111feff0000feff3939fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1717feff0000feff3838fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+dadafdff2626ffff2626ffff0000feff0000feff1b1bfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+c9c9fcff0000feff0000feff0000feff0000feff0000feff0b0bfeff7d7dfffff0f0f0fff0f0f0ff
+d2d2fdff0000feff0000feff0000feff0202ffff0000feff0000feff0000feff0000feffc3c3ffff
+f0f0f0ffddddfcffd7d7fcff1f1fffff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff4d4dfeff0000feff2828fdffc9c9fcff4848fdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff2020fffff0f0f0fff0f0f0ff6969fcff0000feff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff3737fcff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff0000feffacacfdfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffa0a0fdff0000feff0000feff0000feff9595fefff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff1515feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd6d6fdff2626fdff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa9a9fcff6363fcff4343fcff4949fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc3c3fcff7979fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3030fbff0000f8ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9393fcff0000faff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc0c0fdff0000faff0000fcff0000fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0202fbff0000faff0909fcff0707fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4949fcff0000faff0c0cf9ff0606fbff0707faff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff5e5efdff0000fcff0000fcff0808fbff0202fbff0202fbff
+f0f0f0fff0f0f0fff0f0f0ff7474fdff0000fcff0000faff0505faff0b0bfcff0303fcff0505fcff
+f0f0f0fff0f0f0ff8686fdff0000fcff0000faff0303f8ff0000faff0303fcff0000fcff0303fcff
+i$Ks               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff4b4b4bff121212ff1a1a1aff1a1a1aff1a1a1aff121212ff2a2a2afff0f0f0fff0f0f0ff
+f0f0f0ff2a2a2aff121212ff121212ff121212ff121212ff121212ff121212fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff9d9d9dff535353ff121212ff121212ff8d8d8dff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0fff0f0f0ff1a1a1aff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212fff0f0f0fff0f0f0ff535353ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0ffaeaeaeff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff2a2a2affb6b6b6ff323232ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1aff2a2a2aff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff222222fff0f0f0ff4b4b4bff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff121212ff959595fff0f0f0ff959595ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff121212ff535353fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff646464ff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff747474ff121212ff222222fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5c5c5cff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+b6b6b6ff121212ff121212ff121212ff121212ff121212ff121212ff2a2a2afff0f0f0fff0f0f0ff
+aeaeaeff121212ff121212ff121212ff121212ff121212ff121212ff121212fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff5c5c5cff646464ff646464ff646464ff5c5c5cff6c6c6cfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$9s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6b6ff9d9d9dff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff2a2a2aff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff646464ff121212ff121212ff121212ff747474ff959595ff8d8d8dff
+f0f0f0fff0f0f0ffb6b6b6ff121212ff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff747474ff121212ff121212ffa6a6a6fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4b4b4bff121212ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2a2a2aff121212ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff222222ff121212ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff121212ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1a1a1aff121212ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3b3b3bff121212ff434343fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff959595ff121212ff121212ff6c6c6cfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff121212ff858585fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff8d8d8dff121212ff121212ff121212ff2a2a2aff6c6c6cff6c6c6cff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff6c6c6cff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff8d8d8dff222222ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff959595ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7d7d7dff121212ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff121212ff121212ff646464fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff121212ff121212ff121212ff535353ff9d9d9dffb6b6b6ffb6b6b6ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff121212ff121212ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffaeaeaeff434343ff121212ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa6a6a6ff858585ff747474ff7d7d7dff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$9h               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feffb3b3ffffaeaefdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6ffff2222ffff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff7878fdff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff6d6dffff0000feff0000feff0909fcff8080fdffa9a9fcffa7a7fcff
+f0f0f0fff0f0f0ffd4d4fdff0000feff0000feff2727fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8686fdff0000feff0000feffc5c5fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4c4cfdff0000feff2a2afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2828fdff0000feff6b6bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1616fdff0000feff8888fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff0808fdff0000feff8a8afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff1313feff0000feff7e7efdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff3737fcff0000feff4444fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7373fcff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ffaeaefdff0000feff0000feff7b7bfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff0000feff9999fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9e9efdff0000feff0000feff0000feff2222ffff7474ffff7d7dffff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff7777fcff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa1a1fcff1f1ffcff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffb1b1fcffb1b1fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0b0bfefff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff7676fdff0000feff0000feff6e6efdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff0000feff5d5dffffb6b6ffffd5d5feffd1d1feff
+f0f0f0fff0f0f0fff0f0f0ffb8b8fdff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffcecefdff4040fdff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc5c5fcff9b9bfcff8787fcff8b8bfcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$Ah               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7979ffff1717feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffcecefdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9b9bffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6464ffff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1515feff0000feff2424fdff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0e0efdffb7b7fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa8a8fdff0000feff3333fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7171ffff0000feff6767fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff2626ffff0000feff8989fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feffb7b7fcfff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffc8c8fdff0000feff0000fefff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff9c9cfdff0000feff0e0efdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff6a6afdff0000feff5656fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff1b1bffff0000feff9494fdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feffcacafdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffb6b6fdff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff8383ffff0000feff0000feff5353feff5b5bffff5555feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff4242ffff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff0000feff0000feff2e2efdff4a4afdff4040fdff3f3ffcff
+f0f0f0fff0f0f0fff0f0f0ffc6c6ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff9797feff0000feff0707fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff3b3bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff8f8ffeff2222ffff0000feff0000feff0d0dfeff7d7dffffcecefdfff0f0f0fff0f0f0ff
+f0f0f0ff5151feff0000feff0000feff0000feff0000feff0000feff8c8cfdfff0f0f0fff0f0f0ff
+f0f0f0ffd6d6fdffb2b2fdffb5b5fcffb3b3fcffb3b3fcffaeaefdffdcdcfdfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+i$6s               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff858585ff323232ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff9d9d9dff222222ff121212ff090909ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0ff9d9d9dff090909ff090909ff090909ff4b4b4bff858585ffaeaeaeff
+f0f0f0fff0f0f0fff0f0f0ff222222ff090909ff090909ff8d8d8dfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff959595ff090909ff090909ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff4b4b4bff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff121212ff7d7d7dfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff121212ff121212fff0f0f0fff0f0f0ff8d8d8dff535353ff222222ff121212ff
+f0f0f0ff9d9d9dff121212ff1a1a1affaeaeaeff4b4b4bff121212ff121212ff121212ff121212ff
+f0f0f0ff959595ff090909ff121212ff121212ff090909ff121212ff090909ff323232ff535353ff
+f0f0f0ff858585ff121212ff121212ff121212ff090909ff646464ffb6b6b6fff0f0f0fff0f0f0ff
+f0f0f0ff858585ff121212ff121212ff121212ff858585fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff7d7d7dff121212ff121212ff5c5c5cfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff747474ff121212ff121212ffb6b6b6fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff121212ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff5c5c5cff090909ff535353fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff646464ff090909ff4b4b4bfff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff6c6c6cff090909ff323232fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ff858585ff090909ff1a1a1afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0ffaeaeaeff090909ff090909ff959595fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff121212ff090909ff2a2a2afff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff6c6c6cff090909ff090909ff747474fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff090909ff090909ff121212ff535353ff9d9d9dfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffaeaeaeff090909ff090909ff090909ff121212ff121212ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff4b4b4bff090909ff090909ff090909ff121212ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff959595ff747474ff646464ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffd9d9d9ff626262ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff878787ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff353535ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff7f7f7fff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffadadadff121212ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff3e3e3eff020202ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff848484ff050505ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffbebebeff161616ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff494949ff000000ff000000ff000000ff000000ff000000ff
+f0f0f0fff0f0f0fff0f0f0ffa6a6a6ff0e0e0eff000000ff000000ff000000ff000000ff000000ff
+i$allin            18  10 
+0e81acff0e81acff0e81acff0e81acfff0f0f0fff0f0f0fff0f0f0ff0e81acff0e81acff0e81acff0e81acff0e81acfff0f0f0fff0f0f0ff0e81acff0e81acfff0f0f0fff0f0f0ff
+0a7faaff0a7faaff0a7faaff0a7faafff0f0f0fff0f0f0fff0f0f0ff0a7faaff0a7faaff0a7faaff0a7faaff0a7faafff0f0f0fff0f0f0ff0a7faaff0a7faafff0f0f0fff0f0f0ff
+067eaaff067eaaff067eaafff0f0f0fff0f0f0ff067eaafff0f0f0fff0f0f0ff067eaaff067eaaff067eaaff067eaafff0f0f0fff0f0f0ff067eaaff067eaafff0f0f0fff0f0f0ff
+017aa7ff017aa7ff017aa7fff0f0f0fff0f0f0ff017aa7fff0f0f0fff0f0f0ff017aa7ff017aa7ff017aa7ff017aa7fff0f0f0fff0f0f0ff017aa7ff017aa7fff0f0f0fff0f0f0ff
+0078a4ff0078a4fff0f0f0fff0f0f0ff0078a4ff0078a4ff0078a4fff0f0f0fff0f0f0ff0078a4ff0078a4ff0078a4fff0f0f0fff0f0f0ff0078a4ff0078a4fff0f0f0fff0f0f0ff
+0078a0ff0078a0fff0f0f0fff0f0f0ff0078a0ff0078a0ff0078a0fff0f0f0fff0f0f0ff0078a0ff0078a0ff0078a0fff0f0f0fff0f0f0ff0078a0ff0078a0fff0f0f0fff0f0f0ff
+007298ff007298fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff007298ff007298ff007298fff0f0f0fff0f0f0ff007298ff007298fff0f0f0fff0f0f0ff
+006990fff0f0f0fff0f0f0ff006990ff006990ff006990ff006990ff006990fff0f0f0fff0f0f0ff006990ff006990fff0f0f0fff0f0f0ff006990ff006990fff0f0f0fff0f0f0ff
+006388fff0f0f0fff0f0f0ff006388ff006388ff006388ff006388ff006388fff0f0f0fff0f0f0ff006388ff006388fff0f0f0fff0f0f0ff006388ff006388fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff005f82ff005f82ff005f82ff005f82ff005f82ff005f82ff005f82fff0f0f0fff0f0f0ff005f82fff0f0f0fff0f0f0ff005f82ff005f82fff0f0f0fff0f0f0ff
+i$Qh               10  40 
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffcdcdfefff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff5757feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd1d1feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff1717feff0000feff0000feff0000feff2424fdff0808ffff
+f0f0f0fff0f0f0fff0f0f0ffa0a0fdff0000feff0000feff1919fcffd7d7fcfff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff0000feffc1c1fcfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff0a0afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1717feff0000feff2b2bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0808ffff0000feff2121fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0202ffff0000feff2626fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0000feff0000feff3b3bfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0606ffff0000feff3d3dfcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff0f0ffeff0000feff3a3afdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1111feff0000feff3939fcfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff1717feff0000feff3838fdfff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+dadafdff2626ffff2626ffff0000feff0000feff1b1bfffff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+c9c9fcff0000feff0000feff0000feff0000feff0000feff0b0bfeff7d7dfffff0f0f0fff0f0f0ff
+d2d2fdff0000feff0000feff0000feff0202ffff0000feff0000feff0000feff0000feffc3c3ffff
+f0f0f0ffddddfcffd7d7fcff1f1fffff0000feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff4d4dfeff0000feff2828fdffc9c9fcff4848fdff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff2020fffff0f0f0fff0f0f0ff6969fcff0000feff
+f0f0f0fff0f0f0fff0f0f0ff3232ffff0000feff0000fefff0f0f0fff0f0f0fff0f0f0ff3737fcff
+f0f0f0fff0f0f0fff0f0f0ff5f5fffff0000feff0000feffacacfdfff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ffa0a0fdff0000feff0000feff0000feff9595fefff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ff1515feff0000feff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffd6d6fdff2626fdff0000feff0000feff0000feff0000feff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ffa9a9fcff6363fcff4343fcff4949fcff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0fff0f0f0ffc6c6ffffa1a1ffffb6b6fffff0f0f0fff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0fff0f0f0ff3434ffff0000feff0000feff0000feff3d3dfffff0f0f0fff0f0f0ff
+f0f0f0fff0f0f0ff2222ffff0000feff0000feff0202ffff0000feff0000feff7d7dfffff0f0f0ff
+f0f0f0ff9797feff0000feff0000feff0404ffff0606ffff0404ffff0000feff2f2fffff8181ffff
+f0f0f0ff6161ffff0000feff0404ffff0202ffff0404ffff0404ffff0000feff0404ffff1111feff
+f0f0f0ff5353feff0000feff0202ffff0404ffff0606ffff0202ffff0b0bfeff0404ffff0606ffff
+f0f0f0ff7b7bffff0000feff0000feff0000feff0202ffff0000feff0606ffff0202ffff0606ffff
+f0f0f0ffadadffff0000feff0000feff0000feff0202ffff0000feff0202ffff0404ffff0808ffff
+f0f0f0fff0f0f0ff0000feff0000feff0000feff0000feff0000feff0404ffff0404ffff0404ffff
+f0f0f0fff0f0f0ff8f8ffeff0000feff0000feff0202ffff0202ffff0404ffff0606ffff0404ffff
+


### PR DESCRIPTION
Updated version of PokerTH v1.1.2 TM with minor region corrections and a complete font collection now.

TableMap for PokerTH V.1.1.2 10-max DefaultTheme.
For 10-players table size.
Works optimal with default table style gfx (theme) and font smoothing disabled (i.e. advanced system setting set to 'adjust for best performance'),
I preconise also to disable fade-out and flip animation on PokerTH settings.