### PR TITLE
- Fix of Ante display when 'Undefined"

### DIFF
--- a/OpenHoldem/CSymbolEngineTableLimits.cpp
+++ b/OpenHoldem/CSymbolEngineTableLimits.cpp
@@ -226,7 +226,8 @@ void CSymbolEngineTableLimits::AutoLockBlinds() {
     "[CSymbolEngineTableLimits] blinds_locked_for_current_hand: %s\n", 
     Bool2CString(blinds_locked_for_current_hand));
 	// Reasonable blinds guaranteed by the way we guess.
-  // And IsMyTurn guarantees stable input
+	// Previously we was considering IsMyTurn guarantees stable input
+	// and now we rather consider IsHandreset() as some casinos don't let blinds and antes displayed on table until our turn
   if (!blinds_locked_for_current_hand && p_handreset_detector->IsHandreset()) {
 		AutoLockBlindsForCurrentHand();
 		AutoLockBlindsForCashgamesAfterNHands();

--- a/OpenHoldem/CWhiteInfoBox.cpp
+++ b/OpenHoldem/CWhiteInfoBox.cpp
@@ -121,7 +121,7 @@ CString CWhiteInfoBox::InfoText() {
 	result.Append(s);
 
 	// ante
-	if (sym_ante != 0) {
+	if (sym_ante >= 0) {
 		s.Format("  Ante: %s\n", Number2CString(sym_ante));
 		result.Append(s);
 	}


### PR DESCRIPTION
Whitebox displaying "Ante: -1" is fixed when Ante is undefined